### PR TITLE
feat: Add support for tokens with less than 18 decimal places

### DIFF
--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -23,6 +23,7 @@ const TokenInput: React.FC<TokenInputProps> = ({
   burnFee = 0,
 }) => {
   const TranslateString = useI18n()
+
   return (
     <StyledTokenInput>
       <StyledMaxText>

--- a/src/hooks/useStake.ts
+++ b/src/hooks/useStake.ts
@@ -11,8 +11,8 @@ const useStake = (pid: number) => {
   const masterShrimpContract = useMasterShrimp()
 
   const handleStake = useCallback(
-    async (amount: string) => {
-      const txHash = await stake(masterShrimpContract, pid, amount, account)
+    async (amount: string, decimals: number) => {
+      const txHash = await stake(masterShrimpContract, pid, amount, account, decimals)
       dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },

--- a/src/hooks/useUnstake.ts
+++ b/src/hooks/useUnstake.ts
@@ -16,8 +16,8 @@ const useUnstake = (pid: number) => {
   const masterShrimpContract = useMasterShrimp()
 
   const handleUnstake = useCallback(
-    async (amount: string) => {
-      const txHash = await unstake(masterShrimpContract, pid, amount, account)
+    async (amount: string, decimals: number) => {
+      const txHash = await unstake(masterShrimpContract, pid, amount, account, decimals)
       dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },

--- a/src/utils/callHelpers.ts
+++ b/src/utils/callHelpers.ts
@@ -4,9 +4,9 @@ import { ethers } from 'ethers'
 export const approve = async (lpContract, masterShrimpContract, account) =>
   lpContract.methods.approve(masterShrimpContract.options.address, ethers.constants.MaxUint256).send({ from: account })
 
-export const stake = async (masterShrimpContract, pid, amount, account) =>
+export const stake = async (masterShrimpContract, pid, amount, account, decimals = 18) =>
   masterShrimpContract.methods
-    .deposit(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
+    .deposit(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toString())
     .send({ from: account })
     .on('transactionHash', (tx) => tx.transactionHash)
 
@@ -22,9 +22,9 @@ export const smartStakeBnb = async (smartChefContract, amount, account) =>
     .send({ from: account, value: new BigNumber(amount).times(new BigNumber(10).pow(18)).toString() })
     .on('transactionHash', (tx) => tx.transactionHash)
 
-export const unstake = async (masterShrimpContract, pid, amount, account) =>
+export const unstake = async (masterShrimpContract, pid, amount, account, decimals = 18) =>
   masterShrimpContract.methods
-    .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
+    .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toString())
     .send({ from: account })
     .on('transactionHash', (tx) => tx.transactionHash)
 

--- a/src/utils/callHelpers.ts
+++ b/src/utils/callHelpers.ts
@@ -22,11 +22,11 @@ export const smartStakeBnb = async (smartChefContract, amount, account) =>
     .send({ from: account, value: new BigNumber(amount).times(new BigNumber(10).pow(18)).toString() })
     .on('transactionHash', (tx) => tx.transactionHash)
 
-export const unstake = async (masterShrimpContract, pid, amount, account, decimals = 18) =>
-  masterShrimpContract.methods
-    .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toString())
-    .send({ from: account })
-    .on('transactionHash', (tx) => tx.transactionHash)
+export const unstake = async (masterShrimpContract, pid, amount, account, decimals = 18) => masterShrimpContract.methods
+  .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toString())
+  .send({ from: account })
+  .on('transactionHash', (tx) => tx.transactionHash)
+
 
 export const smartShrimpUnstake = async (smartShrimpContract, amount, account) => {
   smartShrimpContract.methods

--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -8,17 +8,25 @@ import { getFullDisplayBalance } from 'utils/formatBalance'
 
 interface DepositModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimals?: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimals: number
   depositFeeBP?: number
 }
 
-const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, tokenName = '', depositFeeBP = 0 }) => {
+const DepositModal: React.FC<DepositModalProps> = ({
+  max,
+  onConfirm,
+  onDismiss,
+  tokenName = '',
+  depositFeeBP = 0,
+  decimals = 18,
+}) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
-  const fullBalance = useMemo(() => getFullDisplayBalance(max), [max])
+  const fullBalance = useMemo(() => getFullDisplayBalance(max, decimals), [max, decimals])
 
   const handleChange = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -49,7 +57,7 @@ const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, 
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimals)
             setPendingTx(false)
             onDismiss()
           }}

--- a/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -41,10 +41,16 @@ const StakeAction: React.FC<FarmCardActionsProps> = ({
   const displayBalance = rawStakedBalance.toLocaleString()
 
   const [onPresentDeposit] = useModal(
-    <DepositModal max={tokenBalance} onConfirm={onStake} tokenName={tokenName} depositFeeBP={depositFeeBP} />,
+    <DepositModal
+      max={tokenBalance}
+      onConfirm={onStake}
+      tokenName={tokenName}
+      depositFeeBP={depositFeeBP}
+      decimals={decimals}
+    />,
   )
   const [onPresentWithdraw] = useModal(
-    <WithdrawModal max={stakedBalance} onConfirm={onUnstake} tokenName={tokenName} />,
+    <WithdrawModal max={stakedBalance} onConfirm={onUnstake} tokenName={tokenName} decimals={decimals} />,
   )
 
   const renderStakingButtons = () =>

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -8,16 +8,17 @@ import { getFullDisplayBalance } from 'utils/formatBalance'
 
 interface WithdrawModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimals?: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimals: number
 }
 
-const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '' }) => {
+const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '', decimals = 18 }) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
-  const fullBalance = useMemo(() => getFullDisplayBalance(max), [max])
+  const fullBalance = useMemo(() => getFullDisplayBalance(max, decimals), [max, decimals])
 
   const handleChange = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -47,7 +48,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimals)
             setPendingTx(false)
             onDismiss()
           }}


### PR DESCRIPTION
Adds support for staking and unstaking tokens that don't use 18 decimals places, such as `DOGE` which uses 8 decimals places.